### PR TITLE
fix: use driver directory setting when copying built drivers

### DIFF
--- a/client/src/control4/stages/copyToOutputStage.ts
+++ b/client/src/control4/stages/copyToOutputStage.ts
@@ -17,9 +17,7 @@ export default class CopyToOutputStage implements BuildStage {
         return new Promise(async (resolve, reject) => {
             try {
                 if (vscode.workspace.getConfiguration('control4.build').get<boolean>('exportToDriverLocation')) {
-                    let root = (this.pkg.control4 && this.pkg.control4.agent) ? 
-                        path.join(process.env.USERPROFILE, "Documents", "Control4", "Agents") :
-                        path.join(process.env.USERPROFILE, "Documents", "Control4", "Drivers")
+                    let root = vscode.workspace.getConfiguration('control4.build').get<string>('directory')
             
                     let dst_file = path.join(root, this.pkg.name + ".c4z")
                     let src_file = path.join(destination, this.pkg.name + ".c4z")

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "url": "https://github.com/annex4-inc/vscode-control4-ext.git"
     },
     "engines": {
-        "vscode": "^1.74.0"
+        "vscode": "^1.80.0"
     },
     "extensionKind": [
         "ui",


### PR DESCRIPTION
Currently the output directory is hard coded to the user's home directory. There is a new property that allows an output directory to be specified, but it looks like the value of that property isn't used when building the driver.