### PR TITLE
feat: add support for identifyText and identifyImage

### DIFF
--- a/client/src/control4/driver.ts
+++ b/client/src/control4/driver.ts
@@ -65,6 +65,8 @@ export class Driver {
     creator: string
     manufacturer: string
     documentation: string
+    identifyImage: string
+    identifyText: string
     name: string
     model: string
     created: Date
@@ -358,6 +360,14 @@ export class Driver {
         // Documentation is mandatory, even if empty
         config.ele("documentation", { file: this.documentation })
 
+        if(this.identifyImage) {
+            config.ele("identify_image").txt(this.identifyImage);
+        }
+
+        if(this.identifyText) {
+            config.ele("identify_text").txt(this.identifyText);
+        }
+
         if (this.tabs && this.tabs.length > 0) {
             let tabs = config.ele("tabs");
             
@@ -515,6 +525,8 @@ export class Driver {
         d.icon = icon
         d.control = devicedata.control
         d.controlmethod = devicedata.controlmethod
+        d.identifyImage = devicedata.identify_image
+        d.identifyText = devicedata.identify_text
         d.driver = devicedata.driver
 
         if (devicedata.capabilities) {

--- a/client/src/resources/schemas/package.json
+++ b/client/src/resources/schemas/package.json
@@ -291,6 +291,14 @@
                     "type": "string",
                     "description": "The path to the documentation file to load"
                 },
+                "identifyImage": {
+                    "type": "string",
+                    "description": "The image used in the identify dialog"
+                },
+                "identifyText": {
+                    "type": "string",
+                    "description": "The text shown in the identify dialog"
+                },
                 "capabilities": {
                     "description": "Determines if the driver supports notifications",
                     "type": "object",


### PR DESCRIPTION
Allows driver developers to specify a `identifyText` and `identifyImage` in `package.json` which then get used in the identify dialog in Composer.

Generates `identify_text` and `identify_image` values in `driver.xml`:

```xml
<config>
    <script jit="1" file="driver.lua"/>
    <documentation file="www/documentation.html"/>
    ...
    <identify_image>www/identify_image.png</identify_image>
    <identify_text>Text to display on the identity dialog.</identify_text>
    ...
</config>
```