### PR TITLE
fix: ensure modules are reloaded when generating a merged source

### DIFF
--- a/client/src/control4/stages/mergeStage.ts
+++ b/client/src/control4/stages/mergeStage.ts
@@ -89,8 +89,8 @@ export default class MergeStage implements BuildStage {
             // Check to make sure the library exists, if not don't include it.
             // This could be caused by a package using its own require statements in which case it should handle the package preload.
             if (fileDocument) {
-                modules = modules + `package.preload['${match[1]}'] = (function(...)\n ${fileDocument} end)\n`
-            }            
+                modules = modules + `package.preload['${match[1]}'] = (function(...)\n  local fn = load([[\n\n${fileDocument}\n\n]])\n\n  return fn()\nend)()\n`
+            }
         }
 
         srcDocument = modules + srcDocument;


### PR DESCRIPTION
Wraps the module source in a `load` call, and returns a function searcher executed as an IIFE. Resulting function in the `package.preload` table is a valid searcher than returns a function that when executed loads the module from source.

Tested using deploy stage to dynamically reload code both within `driver.lua` (which this change doesn't impact) as well as all required files (which this change specifically addresses).

Prior to change, updated code in files included via `require` were not updated when deploying the changes via `LUA_COMMANDS`. After this change, modifications made to included files via `require` reflect changes deployed in new bundle.