### PR TITLE
Add description and tooltip to C4Property

### DIFF
--- a/client/src/control4/C4Property.ts
+++ b/client/src/control4/C4Property.ts
@@ -24,6 +24,8 @@ export class PropertyType {
 export class C4Property {
     @jsonMember name: string
     @jsonMember type: string
+    @jsonMember description: string
+    @jsonMember tooltip: string
     @jsonMember({
         deserializer: value => {
             if (typeof(value) == "string") {


### PR DESCRIPTION
According to [Snap One documentation](https://snap-one.github.io/docs-driverworks-fundamentals/#composerpro-the-interface-into-the-sdk-property-types) `description` and `tooltip` are valid property attributes. 

These attributes were already defined in the [Properties schema](https://github.com/annex4-inc/vscode-control4-ext/blob/master/client/src/resources/schemas/properties.json), but the associated [C4Property](https://github.com/annex4-inc/vscode-control4-ext/blob/master/client/src/control4/C4Property.ts) did not support them. 

After this change, `description` and `tooltip` are successfully written out to `driver.xml` if they are specified on a given property in `properties.c4c`.